### PR TITLE
Replace futures crate with standard library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ github-actions = { repository = "https://github.com/ark0f/hyper-socks2", workflo
 [dependencies]
 hyper = "1"
 async-socks5 = "0.6"
-futures = "0.3"
 tokio = "1.0"
 thiserror = "1.0"
 http = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,6 @@ compile_error!(
 );
 
 use async_socks5::AddrKind;
-use futures::{
-    ready,
-    task::{Context, Poll},
-};
 use http::uri::Scheme;
 use hyper::{
     rt::{Read, Write},
@@ -49,7 +45,12 @@ use hyper_rustls::HttpsConnector;
 #[cfg(feature = "tls")]
 use hyper_tls::HttpsConnector;
 use hyper_util::rt::TokioIo;
-use std::{future::Future, io, pin::Pin};
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
 use tokio::io::BufStream;
 use tower_service::Service;
 


### PR DESCRIPTION
Seems to be able to use standard library instead of `futures` crate at its MSRV 1.75.0.